### PR TITLE
Feature/media details screen rating

### DIFF
--- a/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/mediadetails/components/MoreLikeThisSection.kt
+++ b/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/mediadetails/components/MoreLikeThisSection.kt
@@ -1,13 +1,12 @@
 package com.berlin.aflami.screens.mediadetails.components
 
+import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -34,7 +33,8 @@ fun MoreLikeThisSection(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(196.dp)
-                    .clickable { onMediaClick(media.id,mediaType) },
+                    .clickable { onMediaClick(media.id,mediaType)
+                               Log.d("MoreLikeThisComposable", "ID= ${media.id} , Type= $mediaType")},
                 mediaImg = media.poster,
                 title = media.title,
                 typeOfMedia = if (mediaType == MediaType.MOVIE) stringResource( R.string.movie) else stringResource( R.string.Tv_Show),

--- a/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/mediadetails/components/MoreLikeThisSection.kt
+++ b/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/mediadetails/components/MoreLikeThisSection.kt
@@ -1,6 +1,5 @@
 package com.berlin.aflami.screens.mediadetails.components
 
-import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -33,8 +32,7 @@ fun MoreLikeThisSection(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(196.dp)
-                    .clickable { onMediaClick(media.id,mediaType)
-                               Log.d("MoreLikeThisComposable", "ID= ${media.id} , Type= $mediaType")},
+                    .clickable { onMediaClick(media.id,mediaType) },
                 mediaImg = media.poster,
                 title = media.title,
                 typeOfMedia = if (mediaType == MediaType.MOVIE) stringResource( R.string.movie) else stringResource( R.string.Tv_Show),

--- a/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/mediadetails/screen/MediaDetailsScreen.kt
+++ b/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/mediadetails/screen/MediaDetailsScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -56,9 +55,8 @@ import com.berlin.designsystem.R
 
 @Composable
 fun MediaDetailsScreen(
-    mediaId: Long,
-    mediaType: MediaType,
     viewModel: MediaDetailsViewModel = hiltViewModel(),
+) {
     val navController = Theme.navController
     val uiState by viewModel.state.collectAsState()
     val tabSelected by viewModel.tabSelectedUiState.collectAsState()
@@ -115,10 +113,7 @@ fun MediaDetailsScreen(
             description = stringResource(com.berlin.ui.R.string.login_required_warning)
         )
     }
-
-
 }
-
 
 private fun onReceiveMediaDetailsEffect(
     navController: NavController,
@@ -127,8 +122,10 @@ private fun onReceiveMediaDetailsEffect(
     when (mediaDetailsScreenEffect) {
         is MediaDetailsScreenEffect.NavigateToShowAllCastScreen -> {
             navController.navigate(
-                CastDestination(mediaDetailsScreenEffect.mediaId,
-                    mediaDetailsScreenEffect.mediaType)
+                CastDestination(
+                    mediaDetailsScreenEffect.mediaId,
+                    mediaDetailsScreenEffect.mediaType
+                )
             )
         }
 
@@ -189,7 +186,7 @@ fun MediaDetailsContent(
             item {
                 BackdropPager(
                     state = state,
-                    onPlayClick = { listener.onPlayClicked(state.id,state.mediaType) })
+                    onPlayClick = { listener.onPlayClicked(state.id, state.mediaType) })
             }
 
             item {
@@ -220,11 +217,13 @@ fun MediaDetailsContent(
                 TabSection(
                     tabState = mediaChips,
                     rowState = state.rowSection,
-                    onChipClick = { tab-> listener.onTabSelected(tab)},
+                    onChipClick = { tab -> listener.onTabSelected(tab) },
                     isReviewExpanded = { id -> state.expandedReviewIds.contains(id) },
                     onToggleReviewExpand = { id -> listener.onReadMoreReviewClicked(id) },
-                    onMediaClick = { mediaId, type -> listener.onMediaClicked(mediaId, type)
-                        Log.d("MoreLikeThisInScreen", "ID= $mediaId , Type= $type")},
+                    onMediaClick = { mediaId, type ->
+                        listener.onMediaClicked(mediaId, type)
+                        Log.d("MoreLikeThisInScreen", "ID= $mediaId , Type= $type")
+                    },
 
                     mediaType = mediaType,
                 )
@@ -248,10 +247,10 @@ fun MediaDetailsContent(
         )
 
         if (state.showRatingDialog && state.selectedRatingMediaId != null) {
-                RateDialog(
-                    onDismiss = {listener.onCancelRatingClicked()},
-                    onRate = {rating -> listener.onSubmitRateClicked(rating)}
-                )
+            RateDialog(
+                onDismiss = { listener.onCancelRatingClicked() },
+                onRate = { rating -> listener.onSubmitRateClicked(rating) }
+            )
         }
 
 //        if (state.showAddToListDialog && state.selectedAddToListMediaId != null) {

--- a/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/mediadetails/screen/MediaDetailsScreen.kt
+++ b/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/mediadetails/screen/MediaDetailsScreen.kt
@@ -1,5 +1,6 @@
 package com.berlin.aflami.screens.mediadetails.screen
 
+import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.fadeIn
@@ -18,6 +19,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -35,6 +37,7 @@ import com.berlin.aflami.screens.NoInternetConnectionPlaceholder
 import com.berlin.aflami.navigation.MediaDetailsDestination
 import com.berlin.aflami.screens.mediadetails.components.BackdropPager
 import com.berlin.aflami.screens.mediadetails.components.LoginRequiredDialog
+import com.berlin.aflami.screens.mediadetails.components.RateDialog
 import com.berlin.aflami.screens.mediadetails.components.screensections.CastSection
 import com.berlin.aflami.screens.mediadetails.components.screensections.DescriptionSection
 import com.berlin.aflami.screens.mediadetails.components.screensections.MediaOverviewSection
@@ -95,16 +98,8 @@ fun MediaDetailsScreen(
             state = uiState,
             listener = viewModel,
             isDescriptionExpanded = viewModel.isDescriptionExpanded(),
-            onToggleDescriptionExpand = { viewModel.onReadMoreDescriptionClicked() },
             mediaChips = tabSelected.tab,
-            onChipClick = { tab ->
-                viewModel.toggleMovieDetailsTab(
-                    tab = tab,
-                    mediaId = viewModel.mediaId,
-                    mediaType = viewModel.mediaType,
-                )
-            },
-            mediaType = viewModel.mediaType
+            mediaType = viewModel.mediaType,
         )
     }
     AnimatedVisibility(
@@ -121,6 +116,8 @@ fun MediaDetailsScreen(
             description = stringResource(com.berlin.ui.R.string.login_required_warning)
         )
     }
+
+
 }
 
 
@@ -131,7 +128,8 @@ private fun onReceiveMediaDetailsEffect(
     when (mediaDetailsScreenEffect) {
         is MediaDetailsScreenEffect.NavigateToShowAllCastScreen -> {
             navController.navigate(
-                CastDestination(mediaDetailsScreenEffect.mediaId, mediaDetailsScreenEffect.mediaType)
+                CastDestination(mediaDetailsScreenEffect.mediaId,
+                    mediaDetailsScreenEffect.mediaType)
             )
         }
 
@@ -144,8 +142,7 @@ private fun onReceiveMediaDetailsEffect(
                 VideoWebViewDestination(mediaDetailsScreenEffect.videoUrl)
             )
         }
-        is MediaDetailsScreenEffect.ShowAddToFavoriteListDialog ->{}
-        is MediaDetailsScreenEffect.ShowRatingDialog -> {}
+
         is MediaDetailsScreenEffect.NavigateToMediaDetails -> {
             navController.navigate(
                 MediaDetailsDestination(
@@ -168,9 +165,7 @@ fun MediaDetailsContent(
     state: MediaDetailsUiState,
     listener: MediaInteractionListener,
     isDescriptionExpanded: Boolean,
-    onToggleDescriptionExpand: () -> Unit,
     mediaChips: MovieDetailsTabs,
-    onChipClick: (MovieDetailsTabs) -> Unit,
     mediaType: MediaType,
 ) {
     val listState = rememberLazyListState()
@@ -204,7 +199,7 @@ fun MediaDetailsContent(
             item {
                 DescriptionSection(
                     state.overview, isExpanded = isDescriptionExpanded,
-                    onToggleExpand = onToggleDescriptionExpand
+                    onToggleExpand = { listener.onReadMoreDescriptionClicked() }
                 )
             }
             item {
@@ -226,10 +221,12 @@ fun MediaDetailsContent(
                 TabSection(
                     tabState = mediaChips,
                     rowState = state.rowSection,
-                    onChipClick = onChipClick,
+                    onChipClick = { tab-> listener.onTabSelected(tab)},
                     isReviewExpanded = { id -> state.expandedReviewIds.contains(id) },
                     onToggleReviewExpand = { id -> listener.onReadMoreReviewClicked(id) },
-                    onMediaClick = { mediaId, type -> listener.onMediaClicked(mediaId, type) },
+                    onMediaClick = { mediaId, type -> listener.onMediaClicked(mediaId, type)
+                        Log.d("MoreLikeThisInScreen", "ID= $mediaId , Type= $type")},
+
                     mediaType = mediaType,
                 )
             }
@@ -244,12 +241,32 @@ fun MediaDetailsContent(
             lastOption = painterResource(R.drawable.ic_rounded_add_heart),
             onFirstOptionClicked = { listener.onRateIconClicked(state.id) },
             onLastOptionClicked = {
-                listener.onAddMediaToFavouriteListClicked(0, state.id.toInt())
+                listener.onAddMediaToFavouriteListClicked(0, state.id)
             },
             onNavigateBackClicked = { listener.onBackClicked() },
             optionContainerColor = Theme.color.surfaceHigh,
             containerColor = Color.Unspecified,
         )
+
+        if (state.showRatingDialog && state.selectedRatingMediaId != null) {
+                RateDialog(
+                    onDismiss = {listener.onCancelRatingClicked()},
+                    onRate = {rating -> listener.onSubmitRateClicked(rating)}
+                )
+        }
+
+//        if (state.showAddToListDialog && state.selectedAddToListMediaId != null) {
+//            AddToListDialog(
+//                mediaId = uiState.selectedAddToListMediaId,
+//                favouriteListId = uiState.selectedFavouriteListId,
+//                onConfirm = { listId ->
+//                    viewModel.onSelectFavouriteList(listId)
+//                },
+//                onDismiss = {
+//                    viewModel.onCancelAddingToFavouriteClicked()
+//                }
+//            )
+//        }
     }
 
 }

--- a/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/mediadetails/screen/MediaDetailsScreen.kt
+++ b/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/mediadetails/screen/MediaDetailsScreen.kt
@@ -1,6 +1,5 @@
 package com.berlin.aflami.screens.mediadetails.screen
 
-import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.fadeIn
@@ -222,7 +221,6 @@ fun MediaDetailsContent(
                     onToggleReviewExpand = { id -> listener.onReadMoreReviewClicked(id) },
                     onMediaClick = { mediaId, type ->
                         listener.onMediaClicked(mediaId, type)
-                        Log.d("MoreLikeThisInScreen", "ID= $mediaId , Type= $type")
                     },
 
                     mediaType = mediaType,
@@ -252,19 +250,6 @@ fun MediaDetailsContent(
                 onRate = { rating -> listener.onSubmitRateClicked(rating) }
             )
         }
-
-//        if (state.showAddToListDialog && state.selectedAddToListMediaId != null) {
-//            AddToListDialog(
-//                mediaId = uiState.selectedAddToListMediaId,
-//                favouriteListId = uiState.selectedFavouriteListId,
-//                onConfirm = { listId ->
-//                    viewModel.onSelectFavouriteList(listId)
-//                },
-//                onDismiss = {
-//                    viewModel.onCancelAddingToFavouriteClicked()
-//                }
-//            )
-//        }
     }
 
 }

--- a/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/mediadetails/screen/MediaDetailsScreen.kt
+++ b/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/mediadetails/screen/MediaDetailsScreen.kt
@@ -24,12 +24,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.KeyboardType.Companion.Uri
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.berlin.aflami.component.CircularProgressIndicator
 import com.berlin.aflami.component.DefaultBar
 import com.berlin.aflami.navigation.CastDestination
+import com.berlin.aflami.navigation.LoginDestination
 import com.berlin.aflami.navigation.VideoWebViewDestination
 import com.berlin.aflami.screens.NoInternetConnectionPlaceholder
 import com.berlin.aflami.navigation.MediaDetailsDestination
@@ -114,7 +114,7 @@ fun MediaDetailsScreen(
     ) {
         LoginRequiredDialog(
             onLoginClick = {
-                viewModel.showLoginDialog(false)
+                viewModel.onLoginButtonClicked()
             },
             onDismiss = { viewModel.showLoginDialog(false) },
             title = stringResource(com.berlin.ui.R.string.login_required),
@@ -155,6 +155,10 @@ private fun onReceiveMediaDetailsEffect(
             ){
                 launchSingleTop = true
             }
+        }
+
+        MediaDetailsScreenEffect.NavigateToLogin -> {
+            navController.navigate(LoginDestination)
         }
     }
 }
@@ -244,7 +248,7 @@ fun MediaDetailsContent(
             },
             onNavigateBackClicked = { listener.onBackClicked() },
             optionContainerColor = Theme.color.surfaceHigh,
-            containerColor = Color.Unspecified, // transparent so Modifier.background takes effect
+            containerColor = Color.Unspecified,
         )
     }
 

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaDetailsScreenEffect.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaDetailsScreenEffect.kt
@@ -16,4 +16,6 @@ sealed class MediaDetailsScreenEffect {
         val favouriteListId: Int,
         val mediaId: Int
     ) : MediaDetailsScreenEffect()
+
+    data object NavigateToLogin : MediaDetailsScreenEffect()
 }

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaDetailsScreenEffect.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaDetailsScreenEffect.kt
@@ -10,12 +10,5 @@ sealed class MediaDetailsScreenEffect {
         val mediaType: MediaType
     ) : MediaDetailsScreenEffect()
     data class NavigateToMediaDetails(val mediaId: Long, val mediaType: MediaType): MediaDetailsScreenEffect()
-
-    data class ShowRatingDialog(val id: Long) : MediaDetailsScreenEffect()
-    data class ShowAddToFavoriteListDialog(
-        val favouriteListId: Int,
-        val mediaId: Int
-    ) : MediaDetailsScreenEffect()
-
     data object NavigateToLogin : MediaDetailsScreenEffect()
 }

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaDetailsViewModel.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaDetailsViewModel.kt
@@ -19,6 +19,7 @@ import com.berlin.aflami.viewmodel.shareduistate.MediaType
 import com.berlin.aflami.viewmodel.util.toggle
 import com.berlin.entity.Episodes
 import com.berlin.viewModel.R
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -39,7 +40,6 @@ import usecase.mediadetails.GetSimilarMoviesUseCase
 import usecase.mediadetails.GetSimilarSeriesUseCase
 import usecase.mediadetails.GetTVShowVideos
 import usecase.mediadetails.GetTvShowDetailsUseCase
-import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 
@@ -81,11 +81,11 @@ class MediaDetailsViewModel @Inject constructor(
     private val _showLoginRequiredDialog = MutableStateFlow(false)
     val showLoginRequiredDialog = _showLoginRequiredDialog.asStateFlow()
 
-    val mediaId: Long = mediaDetailsArgs.mediaId?:0
-    val mediaType: MediaType = mediaDetailsArgs.mediaType?: MediaType.MOVIE
+    val mediaId: Long = mediaDetailsArgs.mediaId ?: 0
+    val mediaType: MediaType = mediaDetailsArgs.mediaType ?: MediaType.MOVIE
 
     init {
-        playButtonEnable( mediaId,  mediaType)
+        playButtonEnable(mediaId, mediaType)
         getMediaCast(mediaId = mediaId, mediaType = mediaType)
         getMediaDetails(mediaId = mediaId, mediaType = mediaType)
         onShowMoreMediaLikeThisClicked(mediaId = mediaId, mediaType = mediaType)
@@ -177,7 +177,7 @@ class MediaDetailsViewModel @Inject constructor(
         }
     }
 
-    private fun playButtonEnable(id: Long,type: MediaType){
+    private fun playButtonEnable(id: Long, type: MediaType) {
         tryToCall(
             call = {
                 when (type) {
@@ -267,8 +267,7 @@ class MediaDetailsViewModel @Inject constructor(
 
     override fun onSubmitRateClicked(rate: Int) {
         val mediaId = _state.value.selectedRatingMediaId ?: return
-        // Handle the actual rating submission here,
-        // e.g., call usecase.submitRating(mediaId, rating)
+        //TODO: Handle the actual rating submission here, e.g., call usecase.submitRating(mediaId, rating)
         _state.update {
             it.copy(
                 showRatingDialog = false,
@@ -323,11 +322,18 @@ class MediaDetailsViewModel @Inject constructor(
             if (current.tab == tab) return@update current
 
             when (tab) {
-                MovieDetailsTabs.MORE_LIKE_THIS -> onShowMoreMediaLikeThisClicked(mediaId, mediaType)
+                MovieDetailsTabs.MORE_LIKE_THIS -> onShowMoreMediaLikeThisClicked(
+                    mediaId,
+                    mediaType
+                )
+
                 MovieDetailsTabs.REVIEWS -> onShowReviewsClicked(mediaId, mediaType)
                 MovieDetailsTabs.GALLERY -> onShowMediaGalleryClicked(mediaId, mediaType)
                 MovieDetailsTabs.COMPANY_PRODUCTION -> onShowCompanyProductionClicked()
-                MovieDetailsTabs.SEASON -> onSeasonsClicked(_state.value.id, _state.value.numberOfSeasons ?: 0)
+                MovieDetailsTabs.SEASON -> onSeasonsClicked(
+                    _state.value.id,
+                    _state.value.numberOfSeasons ?: 0
+                )
             }
 
             current.copy(tab = tab, isSelected = true)

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaDetailsViewModel.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaDetailsViewModel.kt
@@ -41,6 +41,8 @@ import usecase.mediadetails.GetTVShowVideos
 import usecase.mediadetails.GetTvShowDetailsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+
+
 @HiltViewModel
 class MediaDetailsViewModel @Inject constructor(
     private val getMovieDetailsUseCase: GetMovieDetailsUseCase,
@@ -88,7 +90,6 @@ class MediaDetailsViewModel @Inject constructor(
         getMediaDetails(mediaId = mediaId, mediaType = mediaType)
         onShowMoreMediaLikeThisClicked(mediaId = mediaId, mediaType = mediaType)
     }
-
 
     fun getMediaDetails(mediaId: Long, mediaType: MediaType) {
 

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaDetailsViewModel.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaDetailsViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import usecase.auth.IsLoggedInUseCase
 import usecase.mediadetails.AddContinueWatchingMovieUseCase
 import usecase.mediadetails.AddContinueWatchingTVShowUseCase
 import usecase.mediadetails.GetMovieCastUseCase
@@ -54,6 +55,7 @@ class MediaDetailsViewModel(
     private val addContinueWatchingTVShowUseCase: AddContinueWatchingTVShowUseCase,
     private val getMovieVideos: GetMovieVideos,
     private val getTvShowVideos: GetTVShowVideos,
+    private val isLoggedInUseCase: IsLoggedInUseCase,
     val mediaId: Long,
     val mediaType: MediaType
 ) : BaseViewModel<MediaDetailsUiState, MediaDetailsScreenEffect>(
@@ -66,8 +68,6 @@ class MediaDetailsViewModel(
         val NO_MORE_MEDIA = R.string.there_is_no_more_media
         val NO_COMPANY_PRODUCTION = R.string.there_is_no_company_production
     }
-
-//    val mediaType = MediaType.valueOf(mediaType)
 
     private val _tabSelectedUiState = MutableStateFlow(MovieDetailsTabsUiState())
     val tabSelectedUiState = _tabSelectedUiState.asStateFlow()
@@ -225,25 +225,26 @@ class MediaDetailsViewModel(
     }
 
     override fun onRateIconClicked(id: Long) {
-        if (true) {
-            _showLoginRequiredDialog.value = true
-        } else {
-            sendNewEffect(MediaDetailsScreenEffect.ShowRatingDialog(id))
+        checkLoginThen {
+            updateState {
+                it.copy(
+                    showRatingDialog = true,
+                    selectedRatingMediaId = id
+                )
+            }
         }
     }
 
-    override fun onAddMediaToFavouriteListClicked(favouriteListId: Int, mediaId: Int) {
-        if (true) {
-            _showLoginRequiredDialog.value = true
-        } else {
-            sendNewEffect(
-                MediaDetailsScreenEffect.ShowAddToFavoriteListDialog(
-                    favouriteListId = favouriteListId,
-                    mediaId = mediaId
+    override fun onAddMediaToFavouriteListClicked(favouriteListId: Int, mediaId: Long) {
+        checkLoginThen {
+            updateState {
+                it.copy(
+                    showAddToListDialog = true,
+                    selectedFavouriteListId = favouriteListId,
+                    selectedAddToListMediaId = mediaId
                 )
-            )
+            }
         }
-
     }
 
     //Dialog Buttons Interactions
@@ -255,18 +256,38 @@ class MediaDetailsViewModel(
 
     override fun onSelectRateClicked(rate: Float) {
 
+
     }
 
-    override fun onSubmitRateClicked(rate: Float) {
-
+    override fun onSubmitRateClicked(rate: Int) {
+        val mediaId = _state.value.selectedRatingMediaId ?: return
+        // Handle the actual rating submission here,
+        // e.g., call usecase.submitRating(mediaId, rating)
+        _state.update {
+            it.copy(
+                showRatingDialog = false,
+                selectedRatingMediaId = null
+            )
+        }
     }
 
     override fun onCancelRatingClicked() {
-
+        updateState {
+            it.copy(
+                showRatingDialog = false,
+                selectedRatingMediaId = null
+            )
+        }
     }
 
     override fun onSelectFavouriteList(favouriteListId: Int) {
-
+        updateState {
+            it.copy(
+                showAddToListDialog = false,
+                selectedAddToListMediaId = null,
+                selectedFavouriteListId = null
+            )
+        }
     }
 
     override fun onCreateNewFavouriteListClicked() {
@@ -290,6 +311,22 @@ class MediaDetailsViewModel(
     }
 
     //Tab Section Interactions
+
+    override fun onTabSelected(tab: MovieDetailsTabs) {
+        _tabSelectedUiState.update { current ->
+            if (current.tab == tab) return@update current
+
+            when (tab) {
+                MovieDetailsTabs.MORE_LIKE_THIS -> onShowMoreMediaLikeThisClicked(mediaId, mediaType)
+                MovieDetailsTabs.REVIEWS -> onShowReviewsClicked(mediaId, mediaType)
+                MovieDetailsTabs.GALLERY -> onShowMediaGalleryClicked(mediaId, mediaType)
+                MovieDetailsTabs.COMPANY_PRODUCTION -> onShowCompanyProductionClicked()
+                MovieDetailsTabs.SEASON -> onSeasonsClicked(_state.value.id, _state.value.numberOfSeasons ?: 0)
+            }
+
+            current.copy(tab = tab, isSelected = true)
+        }
+    }
 
     override fun onShowMoreMediaLikeThisClicked(mediaId: Long, mediaType: MediaType) {
         updateState {
@@ -441,6 +478,7 @@ class MediaDetailsViewModel(
         )
     }
 
+
     override fun onSeasonsClicked(seriesId: Long, numberOfSeasons: Int) {
         updateState {
             it.copy(
@@ -501,43 +539,6 @@ class MediaDetailsViewModel(
         )
     }
 
-    fun toggleMovieDetailsTab(
-        tab: MovieDetailsTabs,
-        mediaId: Long,
-        mediaType: MediaType,
-    ) {
-        _tabSelectedUiState.update { current ->
-            if (current.tab == tab) return@update current
-
-            when (tab) {
-                MovieDetailsTabs.MORE_LIKE_THIS -> onShowMoreMediaLikeThisClicked(
-                    mediaId = mediaId,
-                    mediaType = mediaType
-                )
-
-                MovieDetailsTabs.REVIEWS -> onShowReviewsClicked(
-                    mediaId = mediaId,
-                    mediaType = mediaType
-                )
-
-                MovieDetailsTabs.GALLERY -> onShowMediaGalleryClicked(
-                    id = mediaId,
-                    mediaType = mediaType
-                )
-
-                MovieDetailsTabs.COMPANY_PRODUCTION -> onShowCompanyProductionClicked()
-                MovieDetailsTabs.SEASON -> onSeasonsClicked(
-                    _state.value.id,
-                    _state.value.numberOfSeasons ?: 0
-                )
-            }
-            current.copy(
-                tab = tab,
-                isSelected = true
-            )
-        }
-    }
-
     private fun handleErrorState(errorUiState: ErrorUiState, updateRowSection: Boolean = false) {
         updateState {
             val rowSection = if (updateRowSection) {
@@ -549,6 +550,16 @@ class MediaDetailsViewModel(
                 rowSection = rowSection,
                 isLoading = false
             )
+        }
+    }
+
+    private fun checkLoginThen(actionIfLoggedIn: () -> Unit) {
+        viewModelScope.launch {
+            if (isLoggedInUseCase()) {
+                actionIfLoggedIn()
+            } else {
+                _showLoginRequiredDialog.value = true
+            }
         }
     }
 }

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaDetailsViewModel.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaDetailsViewModel.kt
@@ -232,18 +232,6 @@ class MediaDetailsViewModel(
         }
     }
 
-    override fun onSelectRateClicked(rate: Float) {
-
-    }
-
-    override fun onSubmitRateClicked(rate: Float) {
-
-    }
-
-    override fun onCancelRatingClicked() {
-
-    }
-
     override fun onAddMediaToFavouriteListClicked(favouriteListId: Int, mediaId: Int) {
         if (true) {
             _showLoginRequiredDialog.value = true
@@ -255,6 +243,25 @@ class MediaDetailsViewModel(
                 )
             )
         }
+
+    }
+
+    //Dialog Buttons Interactions
+
+    override fun onLoginButtonClicked() {
+        _showLoginRequiredDialog.value = false
+        sendNewEffect(MediaDetailsScreenEffect.NavigateToLogin)
+    }
+
+    override fun onSelectRateClicked(rate: Float) {
+
+    }
+
+    override fun onSubmitRateClicked(rate: Float) {
+
+    }
+
+    override fun onCancelRatingClicked() {
 
     }
 
@@ -281,6 +288,8 @@ class MediaDetailsViewModel(
     override fun onCancelCreatingNewListClicked() {
 
     }
+
+    //Tab Section Interactions
 
     override fun onShowMoreMediaLikeThisClicked(mediaId: Long, mediaType: MediaType) {
         updateState {
@@ -360,8 +369,6 @@ class MediaDetailsViewModel(
             onError = { errorState -> handleErrorState(errorState, updateRowSection = true) },
         )
     }
-
-
 
     override fun onShowMediaGalleryClicked(id: Long, mediaType: MediaType) {
         updateState {

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaInteractionListener.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaInteractionListener.kt
@@ -17,6 +17,7 @@ interface MediaInteractionListener :
     fun onReadMoreReviewClicked(id: String)
     fun onShowCastClicked()
     fun onMediaClicked(mediaId: Long, mediaType: MediaType)
+    fun onLoginButtonClicked()
 
 }
 

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaInteractionListener.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/details/MediaInteractionListener.kt
@@ -1,5 +1,6 @@
 package com.berlin.aflami.viewmodel.mediadetails.details
 
+import com.berlin.aflami.viewmodel.mediadetails.MovieDetailsTabs
 import com.berlin.aflami.viewmodel.reusableinteractionlistener.addtofavourite.AddToFavouriteInteractionListener
 import com.berlin.aflami.viewmodel.reusableinteractionlistener.createnewlist.CreateNewListInteractionListener
 import com.berlin.aflami.viewmodel.reusableinteractionlistener.rate.RateInteractionListener
@@ -26,6 +27,7 @@ interface ExtraMediaContentInteractionListener : TVShowSeasonsInteractionListene
     fun onShowReviewsClicked(mediaId: Long, mediaType: MediaType)
     fun onShowMediaGalleryClicked(id:Long,mediaType: MediaType)
     fun onShowCompanyProductionClicked()
+    fun onTabSelected(tab: MovieDetailsTabs)
 }
 
 interface TVShowSeasonsInteractionListener {

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/uistate/MediaDetailsUiState.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/uistate/MediaDetailsUiState.kt
@@ -35,7 +35,13 @@ data class MediaDetailsUiState(
     val duration: String? = null,
     val hasVideo: Boolean = false,
     val error: String? = null,
-    val rowSection: RowSectionUiState = RowSectionUiState.Loading
+    val rowSection: RowSectionUiState = RowSectionUiState.Loading,
+
+    val showRatingDialog: Boolean = false,
+    val showAddToListDialog: Boolean = false,
+    val selectedRatingMediaId: Long? = null,
+    val selectedAddToListMediaId: Long? = null,
+    val selectedFavouriteListId: Int? = null
 ) {
     fun toMovie(): Movie {
         return Movie(

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/uistate/MediaDetailsUiState.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/mediadetails/uistate/MediaDetailsUiState.kt
@@ -11,7 +11,7 @@ data class MediaDetailsUiState(
     val title: String = "",
     val overview: String = "",
     val posterUrl: String = "",
-    val videoUrl:String?="",
+    val videoUrl: String? = "",
     val backdropUrl: String? = "",
     val genres: List<String> = emptyList(),
     val posterImages: List<String> = emptyList(),

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/reusableinteractionlistener/addtofavourite/AddToFavouriteInteractionListener.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/reusableinteractionlistener/addtofavourite/AddToFavouriteInteractionListener.kt
@@ -1,7 +1,7 @@
 package com.berlin.aflami.viewmodel.reusableinteractionlistener.addtofavourite
 
 interface AddToFavouriteInteractionListener {
-    fun onAddMediaToFavouriteListClicked(favouriteListId: Int, mediaId: Int)
+    fun onAddMediaToFavouriteListClicked(favouriteListId: Int, mediaId: Long)
     fun onSelectFavouriteList(favouriteListId: Int)
     fun onCreateNewFavouriteListClicked()
     fun onCancelAddingToFavouriteClicked()

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/reusableinteractionlistener/rate/RateInteractionListener.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/reusableinteractionlistener/rate/RateInteractionListener.kt
@@ -3,6 +3,6 @@ package com.berlin.aflami.viewmodel.reusableinteractionlistener.rate
 interface RateInteractionListener {
     fun onRateIconClicked(id: Long)
     fun onSelectRateClicked(rate: Float)
-    fun onSubmitRateClicked(rate: Float)
+    fun onSubmitRateClicked(rate: Int)
     fun onCancelRatingClicked()
 }


### PR DESCRIPTION
# Refactor MediaDetailsScreen for Consistent Interaction Handling and Dialog State Management

## Description
This PR introduces significant structural and architectural improvements to the MediaDetailsScreen and its ViewModel by ensuring consistent interaction handling, improving state management, centralizing logic within the ViewModel and implement the rating dialog if the user logged in

---

## Changes Made
1. Interaction Handling Unified via MediaInteractionListener

    Introduced fun onTabSelected(tab: MovieDetailsTabs) into MediaInteractionListener.

    Replaced the previously passed onChipClick: (MovieDetailsTabs) -> Unit lambda with a call to listener.onTabSelected(tab) in MediaDetailsContent.

    Renamed and relocated toggleMovieDetailsTab() to onTabSelected() inside the MediaDetailsViewModel.

This eliminates inconsistencies in the way interactions were handled (some through the listener, others directly), and now all interactions are routed uniformly through the MediaInteractionListener contract.

2. Dialog Visibility and Interaction State Moved to ViewModel

    showRatingDialog, selectedRatingMediaId, showAddToListDialog, selectedAddToListMediaId, and selectedFavouriteListId are now part of the ViewModel's UI state.

    These dialog states are managed fully inside the ViewModel using updateState {} calls, just like other ViewModel-controlled UI elements.

Benefits:

    Keeps the screen composables stateless and presentation-focused.

    Improves testability and makes the dialog logic traceable from the ViewModel layer.

    Allows clear separation of view logic and business logic.

3. Removed Unused Screen Effects for Dialogs

    Removed the use of MediaDetailsScreenEffect.ShowRatingDialog and ShowAddToFavoriteListDialog, as these are now directly handled through state.

    Effects are now strictly used for one-shot navigation or imperative events (e.g., NavigateToLogin, PlayMedia).

4. UI Updates

    RateDialog is now conditionally displayed via if (state.showRatingDialog && state.selectedRatingMediaId != null) block.

    AddToListDialog integration has been prepared (commented for now) and will follow the same pattern.
---


## Checklist
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
- [x] Commit messages should follow the atomic commits convention.

---
