### PR TITLE
Fix / improve error handling and UI updates in ListScreen

### DIFF
--- a/data/remote/src/main/kotlin/com/berlin/remote/ApiResponseWrap.kt
+++ b/data/remote/src/main/kotlin/com/berlin/remote/ApiResponseWrap.kt
@@ -1,5 +1,6 @@
 package com.berlin.remote
 
+import android.util.Log
 import com.berlin.exception.AlreadyExistsException
 import com.berlin.exception.ApiException
 import com.berlin.exception.NetworkException
@@ -19,6 +20,9 @@ suspend fun <T> wrapApiResponse(request: suspend () -> Response<T>): T {
             throw ApiException("API error: ${response.code()} - ${response.message()}")
         }
 
+    } catch (ioException: IOException) {
+        Log.d("Khairy", "IO Exception")
+        throw NetworkException("Network error: ${ioException.message}")
     } catch (e: UnknownHostException) {
         throw NetworkException("No internet connection: ${e.message}")
     } catch (e: IOException) {

--- a/data/remote/src/main/kotlin/com/berlin/remote/RetrofitRemoteDataSource.kt
+++ b/data/remote/src/main/kotlin/com/berlin/remote/RetrofitRemoteDataSource.kt
@@ -166,12 +166,14 @@ class RetrofitRemoteDataSource @Inject constructor(
 
     override suspend fun getUserFavouriteLists(page: Int): List<FavouriteListDto> {
         Log.d("Khairy", "remote DS$page")
-        return apiService.getUserLists(
-            accountId = authenticationLocalDataSource.getUserAccountId(),
-            page = page,
-            sessionId = authenticationLocalDataSource.getUserSessionId()
-                ?: throw IllegalStateException("userSessionID == null"),
-        ).body()!!.results ?: emptyList()
+        return wrapApiResponse {
+            apiService.getUserLists(
+                accountId = authenticationLocalDataSource.getUserAccountId(),
+                page = page,
+                sessionId = authenticationLocalDataSource.getUserSessionId()
+                    ?: throw IllegalStateException("userSessionID == null"),
+            )
+        }.results ?: emptyList()
     }
 
     override suspend fun getUserFavouriteListItems(
@@ -321,7 +323,7 @@ class RetrofitRemoteDataSource @Inject constructor(
     }
 
     override suspend fun getMovieGame(): BaseResponse<MovieDetailsDto> {
-       return wrapApiResponse { apiService.getMovieGame() }
+        return wrapApiResponse { apiService.getMovieGame() }
     }
 
     override suspend fun getTVShow(): BaseResponse<TVShowDetailsDto> {

--- a/data/repository/src/main/java/com/berlin/repository/UserFavouriteListRepositoryImpl.kt
+++ b/data/repository/src/main/java/com/berlin/repository/UserFavouriteListRepositoryImpl.kt
@@ -15,6 +15,7 @@ class UserFavouriteListRepositoryImpl @Inject constructor(
     override suspend fun getUserFavouriteLists(pageNumber: Int): List<FavouriteList> {
         Log.d("Khairy", "fav list page = $pageNumber")
         return remoteDataSource.getUserFavouriteLists(page = pageNumber)
+            .ifEmpty { return emptyList() }
             .map { favouriteListDto ->
                 Log.d("Khairy", "repository $favouriteListDto")
                 favouriteListDto.toDomain()

--- a/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/listdetails/component/DeleteListDialog.kt
+++ b/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/listdetails/component/DeleteListDialog.kt
@@ -62,7 +62,7 @@ fun DeleteListDialog(
                 Text(
                     stringResource(R.string.delete),
                     style = Theme.textStyle.label.large,
-                    color = Theme.color.statusColors.redAccent
+                    color = Theme.color.textColors.onPrimary
                 )
             }
         }

--- a/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/lists/ListScreen.kt
+++ b/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/lists/ListScreen.kt
@@ -1,5 +1,6 @@
 package com.berlin.aflami.screens.lists
 
+import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -184,9 +185,11 @@ private fun ListsContent(
             EditListDialog(
                 listId = listScreenState.editListSheetState.requiredListIdToEdit!!,
                 listName = listScreenState.editListSheetState.currentListTitle,
-                onListNameChanged = { interactionListener.onOldListTitleChanged(
-                    it.text
-                ) },
+                onListNameChanged = {
+                    interactionListener.onOldListTitleChanged(
+                        it.text
+                    )
+                },
                 onSaveClick = interactionListener::onSaveOldListTitleToNewTitleClicked,
                 onDismiss = interactionListener::onCancelEditingListClicked,
             )
@@ -194,8 +197,9 @@ private fun ListsContent(
         AnimatedVisibility(
             enter = fadeIn(),
             exit = fadeOut(),
-            visible = (favouriteLists.loadState.refresh !is LoadState.Loading && listScreenState.isUserLoggedIn == true) && favouriteLists.itemCount == 0 && !listScreenState.isScreenLoading && listScreenState.errorMessage != null,
+            visible = favouriteLists.loadState.refresh !is LoadState.Loading && listScreenState.isUserLoggedIn == true && favouriteLists.loadState.refresh is LoadState.Error,
         ) {
+            Log.d("Khairy", "error message = ${listScreenState.errorMessage}")
             NoInternetConnectionPlaceholder(
                 onClick = interactionListener::onClickRetryFetchList
             )
@@ -221,8 +225,11 @@ private fun ListsContent(
         AnimatedVisibility(
             enter = fadeIn(),
             exit = fadeOut(),
-            visible = (favouriteLists.loadState.refresh !is LoadState.Loading && listScreenState.isUserLoggedIn == true) && favouriteLists.itemCount == 0 && !listScreenState.isScreenLoading && listScreenState.errorMessage == null,
+            visible = (favouriteLists.loadState.refresh !is LoadState.Loading
+                    && listScreenState.isUserLoggedIn == true)
+                    && favouriteLists.loadState.refresh !is LoadState.Error,
         ) {
+            Log.d("Khairy", "error message = ${listScreenState.errorMessage}")
             CountryTourExploring(
                 modifier = Modifier
                     .fillMaxSize()
@@ -291,6 +298,7 @@ private fun onReceiveNewEffect(effect: ListScreenEffect, navController: NavContr
         is ListScreenEffect.NavigateToSeeAllListScreen -> navController.navigate(
             ListDetailsDestination(listId = effect.listId, listTitle = effect.listTitle)
         )
+
         ListScreenEffect.NavigateToLoginScreen -> navController.navigate(route = LoginDestination)
     }
 }

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/list/AllFavouriteListsPagingSource.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/list/AllFavouriteListsPagingSource.kt
@@ -11,8 +11,12 @@ class AllFavouriteListsPagingSource(
 ) : BasePagingSource<FavouriteListItemUiState>() {
 
     override suspend fun fetchData(page: Int): List<FavouriteListItemUiState> {
-        return getAllFavouriteListsUseCase.invoke(pageNumber = page).map { favouriteList ->
-            favouriteList.toFavourListItemUiState()
+        return getAllFavouriteListsUseCase.invoke(pageNumber = page).ifEmpty {
+            Log.d("Khairy", "empty lists")
+            return emptyList()
         }
+            .map { favouriteList ->
+                favouriteList.toFavourListItemUiState()
+            }
     }
 }

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/list/ListScreenState.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/list/ListScreenState.kt
@@ -19,6 +19,6 @@ data class ListScreenState(
     val createNewListSheetState: CreateNewListUiState = CreateNewListUiState(),
     val editListSheetState: EditListSheetState = EditListSheetState(),
     val isScreenLoading: Boolean = true,
-    val errorMessage: String? = "",
+    val errorMessage: String? = null,
     val snackBar: SnackBarUiState = SnackBarUiState(),
 )

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/list/ListScreenViewModel.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/list/ListScreenViewModel.kt
@@ -1,5 +1,6 @@
 package com.berlin.aflami.viewmodel.list
 
+import android.util.Log
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.viewModelScope
 import androidx.paging.Pager
@@ -102,14 +103,17 @@ class ListScreenViewModel @Inject constructor(
 
     private fun updateScreenStateWithUserFavouriteLists(userFavouriteLists: Flow<PagingData<FavouriteListItemUiState>>) {
         updateState { screenState ->
+            Log.d("Khairy", "Success}")
+
             screenState.copy(
-                favouriteList = userFavouriteLists, isScreenLoading = false
+                favouriteList = userFavouriteLists, isScreenLoading = false, errorMessage = null
             )
         }
     }
 
     private fun updateScreenStateWithErrorMessage(errorUiState: ErrorUiState) {
         updateState { screenState ->
+            Log.d("Khairy", "error message in viewModel = ${errorUiState.message}")
             screenState.copy(
                 errorMessage = errorUiState.message, isScreenLoading = false
             )


### PR DESCRIPTION
- Set `errorMessage` to null by default in `ListScreenState`.
- Wrap API call in `getUserFavouriteLists` within `RetrofitRemoteDataSource` with `wrapApiResponse` for consistent error handling.
- Change delete button text color in `DeleteListDialog` to `onPrimary`.
- Adjust visibility conditions for error and empty state placeholders in `ListScreen` based on `LoadState` and `errorMessage`.
