### PR TITLE
fix/item-count-in-list-screen-and-state-for-screen 

### DIFF
--- a/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/lists/ListScreen.kt
+++ b/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/lists/ListScreen.kt
@@ -224,9 +224,11 @@ private fun ListsContent(
         AnimatedVisibility(
             enter = fadeIn(),
             exit = fadeOut(),
-            visible = (favouriteLists.loadState.refresh !is LoadState.Loading
-                    && listScreenState.isUserLoggedIn == true)
-                    && favouriteLists.loadState.refresh !is LoadState.Error,
+            visible = !listScreenState.isScreenLoading &&
+                    listScreenState.isUserLoggedIn == true &&
+                    favouriteLists.loadState.refresh !is LoadState.Loading &&
+                    favouriteLists.loadState.refresh !is LoadState.Error &&
+                    favouriteLists.itemCount == 0
         ) {
             CountryTourExploring(
                 modifier = Modifier

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/list/ListScreenViewModel.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/list/ListScreenViewModel.kt
@@ -6,21 +6,32 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.Pager
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import androidx.paging.map
 import com.berlin.aflami.viewmodel.base.BaseViewModel
 import com.berlin.aflami.viewmodel.base.ErrorUiState
 import com.berlin.aflami.viewmodel.details.movie.SNACK_BAR_STATUS
 import com.berlin.aflami.viewmodel.reusableinteractionlistener.list.addTiList.FavouriteListItemUiState
+import com.berlin.aflami.viewmodel.util.ListCountEventBus
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import usecase.auth.GetLoginUseCase
 import usecase.favouritelist.CreateNewFavouriteListUseCase
 import usecase.favouritelist.EditListTitleUseCase
 import usecase.favouritelist.GetAllFavouriteListsUseCase
 import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.collections.plus
 
 @HiltViewModel
 class ListScreenViewModel @Inject constructor(
@@ -28,6 +39,7 @@ class ListScreenViewModel @Inject constructor(
     private val getAllFavouriteListsUseCase: GetAllFavouriteListsUseCase,
     private val getIsUserLoggedInUseCase: GetLoginUseCase,
     private val editListTitleUseCase: EditListTitleUseCase,
+    private val listCountEventBus: ListCountEventBus,
     favouriteListArgs: FavouriteListArgs,
 ) : BaseViewModel<ListScreenState, ListScreenEffect>(ListScreenState()),
     ListScreenInteractionListener {
@@ -42,6 +54,8 @@ class ListScreenViewModel @Inject constructor(
     val isLoggedIn: StateFlow<Boolean?> = getIsUserLoggedInUseCase().stateIn(
         viewModelScope, SharingStarted.WhileSubscribed(5000), null
     )
+    private val countDeltas = MutableStateFlow<Map<Int, Int>>(emptyMap())
+
 
     init {
         shouldShowEditSheet?.let {
@@ -69,8 +83,19 @@ class ListScreenViewModel @Inject constructor(
             }
         }
         observeLoginStatus()
+        observeCountDeltas()
     }
 
+    private fun observeCountDeltas() {
+        viewModelScope.launch {
+            listCountEventBus.events.collectLatest { (listId, delta) ->
+                countDeltas.update { current ->
+                    val next = (current[listId] ?: 0) + delta
+                    current + (listId to next)
+                }
+            }
+        }
+    }
     private fun observeLoginStatus() {
         viewModelScope.launch {
             isLoggedIn.collect { loggedIn ->
@@ -96,15 +121,29 @@ class ListScreenViewModel @Inject constructor(
         )
     }
 
-    private fun getAllFavouriteListsAsFlow(): Flow<PagingData<FavouriteListItemUiState>> = Pager(
-        config = defaultPageConfigurations(), pagingSourceFactory = {
-            AllFavouriteListsPagingSource(getAllFavouriteListsUseCase)
-        }).flow.cachedIn(viewModelScope)
+    private fun getAllFavouriteListsAsFlow(): Flow<PagingData<FavouriteListItemUiState>> =
+        Pager(
+            config = defaultPageConfigurations(),
+            pagingSourceFactory = { AllFavouriteListsPagingSource(getAllFavouriteListsUseCase) }
+        ).flow.cachedIn(viewModelScope)
 
-    private fun updateScreenStateWithUserFavouriteLists(userFavouriteLists: Flow<PagingData<FavouriteListItemUiState>>) {
+    private fun updateScreenStateWithUserFavouriteLists(
+        userFavouriteLists: Flow<PagingData<FavouriteListItemUiState>>
+    ) {
+        val newList = combine(userFavouriteLists, countDeltas) { paging, deltas ->
+            paging.map { item ->
+                val id = item.listId ?: -1
+                val d = deltas[id] ?: 0
+                item.copy(
+                    numberOfFavouriteMovies = (item.numberOfFavouriteMovies + d).coerceAtLeast(0)
+                )
+            }
+        }.cachedIn(viewModelScope)
+
         updateState { screenState ->
             screenState.copy(
-                favouriteList = userFavouriteLists, isScreenLoading = false, errorMessage = null
+                favouriteList = newList,
+                isScreenLoading = false,
             )
         }
     }
@@ -273,3 +312,4 @@ class ListScreenViewModel @Inject constructor(
             })
     }
 }
+

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/listDetails/ListDetailsScreenState.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/listDetails/ListDetailsScreenState.kt
@@ -4,6 +4,7 @@ package com.berlin.aflami.viewmodel.listDetails
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.paging.PagingData
+import com.berlin.aflami.viewmodel.reusableinteractionlistener.list.addTiList.FavouriteListItemUiState
 import com.berlin.aflami.viewmodel.shareduistate.MovieUiState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
@@ -12,6 +13,8 @@ import kotlinx.coroutines.flow.emptyFlow
 data class ListDetailsScreenState(
     val listTitle: String = "",
     val listId: Int? = null,
+    val numberOfFavouriteMovies: Int = 0,
+    val listItemUiState: FavouriteListItemUiState = FavouriteListItemUiState(),
     val listItems: Flow<PagingData<MovieUiState>> = emptyFlow(),
     val showDeleteListDialog: Boolean = false,
     val isScreenLoading: Boolean = false,

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/listDetails/ListDetailsScreenViewModel.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/listDetails/ListDetailsScreenViewModel.kt
@@ -8,19 +8,20 @@ import androidx.paging.cachedIn
 import com.berlin.aflami.viewmodel.base.BaseViewModel
 import com.berlin.aflami.viewmodel.base.ErrorUiState
 import com.berlin.aflami.viewmodel.shareduistate.MovieUiState
+import com.berlin.aflami.viewmodel.util.ListCountEventBus
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import usecase.favouritelist.DeleteMovieFromUserFavouriteListUseCase
 import usecase.favouritelist.DeleteUserFavouriteListUseCase
-import usecase.favouritelist.GetFavouriteListItemsUseCase
 import javax.inject.Inject
 
 @HiltViewModel
 class ListDetailsScreenViewModel @Inject constructor(
-    private val getAllFavouriteListItemsUseCase: GetFavouriteListItemsUseCase,
     private val deleteMovieFromUserFavouriteListUseCase: DeleteMovieFromUserFavouriteListUseCase,
     private val deleteUserFavouriteListUseCase: DeleteUserFavouriteListUseCase,
     private val favouriteMoviesPagingSourceFactory: FavouriteMoviesPagingSource.Factory,
+    private val listCountEventBus: ListCountEventBus,
     favouriteListDetailsArgs: FavouriteListDetailsArgs,
 ) : BaseViewModel<ListDetailsScreenState, ListDetailsScreenEffect>(
     ListDetailsScreenState()
@@ -30,6 +31,7 @@ class ListDetailsScreenViewModel @Inject constructor(
         ?: throw IllegalArgumentException("list id is null")
     private val favouriteListTitle: String = favouriteListDetailsArgs.favouriteListTitle
         ?: throw IllegalArgumentException("list title is null")
+    private var latestPagingSource: FavouriteMoviesPagingSource? = null
 
     init {
         updateState { screenState ->
@@ -106,12 +108,18 @@ class ListDetailsScreenViewModel @Inject constructor(
     override fun onMovieCardClicked(movieId: Long) =
         sendNewEffect(ListDetailsScreenEffect.NavigateToMovieDetailsScreen(movieId = movieId))
 
+
     override fun onRemoveMovieClicked(listId: Int, movieId: Long) {
         tryToCall(
             call = { deleteMovieFromUserFavouriteListUseCase(listId = listId, movieId = movieId) },
             onSuccess = {
+                latestPagingSource?.invalidate()
+                updateState { screenState ->
+                    screenState.copy(numberOfFavouriteMovies = (screenState.numberOfFavouriteMovies - 1).coerceAtLeast(0))
+                }
+                viewModelScope.launch { listCountEventBus.emit(listId, -1) }
                 getAllFavoriteListItems(favouriteListId = favouriteListId)
-                ListDetailsScreenEffect.ShowDeleteMovieFromListSucceededSnackBar
+                sendNewEffect(ListDetailsScreenEffect.ShowDeleteMovieFromListSucceededSnackBar)
             },
             onError = { sendNewEffect(ListDetailsScreenEffect.ShowDeleteMovieFromListFailedSnackBar) },
         )

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/util/ListCountEventBus.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/util/ListCountEventBus.kt
@@ -1,0 +1,19 @@
+package com.berlin.aflami.viewmodel.util
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ListCountEventBus @Inject constructor() {
+    data class Delta(val listId: Int, val delta: Int)
+
+    private val _events = MutableSharedFlow<Delta>(extraBufferCapacity = 64)
+    val events: SharedFlow<Delta> = _events.asSharedFlow()
+
+    suspend fun emit(listId: Int, delta: Int) {
+        _events.emit(Delta(listId, delta))
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description
Refactor: Update list item count in ListScreen and ListDetailsScreen

This commit introduces a `ListCountEventBus` to synchronize the item count of a favorite list between `ListScreen` and `ListDetailsScreen`.

When a movie is removed from a list in `ListDetailsScreen`:
- The `ListDetailsScreenViewModel` emits an event via `ListCountEventBus` with the list ID and a delta of -1.
- It also invalidates its `PagingSource` to refresh the list.
- The item count in `ListDetailsScreenState` is updated directly.

The `ListScreenViewModel`:
- Observes events from `ListCountEventBus`.
- Maintains a map of list IDs to their respective count deltas.
- Combines the original favorite list PagingData with these deltas to display the updated item counts for each list.

Additionally:
- `ListScreen.kt`: The visibility condition for the "CountryTourExploring" composable (empty state) is updated to consider `listScreenState.isScreenLoading` and `favouriteLists.itemCount == 0` for more accurate display.
- `ListDetailsScreenState.kt`: Added `numberOfFavouriteMovies` and `listItemUiState` to manage the list item count and potentially other list item details.

---

