### PR TITLE
fix login screen flickering and modify password TextField

### DIFF
--- a/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/authentication/LoginScreen.kt
+++ b/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/authentication/LoginScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -52,6 +53,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -242,9 +244,10 @@ private fun FormLogin(
             trailingIcon = R.drawable.eye,
             onTrailingIconClicked = onTrailingIconClicked,
             modifier = Modifier.fillMaxWidth(),
-            maxCharacters = 32
+            maxCharacters = 32,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
 
-        )
+            )
         Spacer(modifier = Modifier.height(8.dp))
 
         Text(

--- a/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/mainactivity/MainActivity.kt
+++ b/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/mainactivity/MainActivity.kt
@@ -35,7 +35,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
-
         splashScreen.setKeepOnScreenCondition {
             mainActivityViewModel.state.value.isLoading
         }
@@ -43,6 +42,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             val profileState by profileViewModel.state.collectAsState()
+            val mainState by mainActivityViewModel.state.collectAsState()
             val isDarkTheme = profileState.isDarkThemeEnabled
             LaunchedEffect(Unit) {
                 profileViewModel.effect.collect { effect ->
@@ -57,8 +57,6 @@ class MainActivity : ComponentActivity() {
                 isDarkTheme = isDarkTheme,
                 selectedLanguage = profileState.selectedLanguage
             ) {
-                val mainState by mainActivityViewModel.state.collectAsState()
-
                 if (!mainState.isLoading) {
                     AflamiNavGraph(
                         navController = Theme.navController,

--- a/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/profile/ProfileScreen.kt
+++ b/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/profile/ProfileScreen.kt
@@ -1,6 +1,9 @@
 package com.berlin.aflami.screens.profile
 
 import androidx.activity.ComponentActivity
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -51,18 +54,30 @@ fun ProfileScreen(
 ) {
     val profileScreenState by viewModel.state.collectAsStateWithLifecycle()
     val navController = Theme.navController
-    when (profileScreenState.isLoggedIn) {
-        null -> {
-            CircularProgressIndicator(
-                modifier = Modifier.fillMaxSize(),
-                text = stringResource(R.string.loading)
-            )
-        }
-        true -> ProfileContent(profileScreenState, viewModel)
-        false -> RequiredLoggedInPlaceholder {
-            navController.navigate(LoginDestination)
-        }
+
+    AnimatedVisibility(
+        enter =  EnterTransition.None ,
+        exit = ExitTransition.None ,
+        visible = profileScreenState.isLoggedIn==null
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.fillMaxSize(),
+            text = stringResource(R.string.loading)
+        )
     }
+
+    AnimatedVisibility(
+        enter =  EnterTransition.None ,
+        exit = ExitTransition.None ,
+        visible = profileScreenState.isLoggedIn==true
+    ) { ProfileContent(profileScreenState, viewModel) }
+
+    AnimatedVisibility(
+        enter =  EnterTransition.None ,
+        exit = ExitTransition.None ,
+        visible = profileScreenState.isLoggedIn==false
+    ) { RequiredLoggedInPlaceholder { navController.navigate(LoginDestination) } }
+
     LaunchedEffect(Unit) {
         viewModel.effect.collect { newEffect ->
             watchHistoryReceiveEffect(navController = navController, effect = newEffect)

--- a/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/profile/ProfileScreen.kt
+++ b/presentation/ui/src/main/kotlin/com/berlin/aflami/screens/profile/ProfileScreen.kt
@@ -16,10 +16,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
+import com.berlin.aflami.component.CircularProgressIndicator
 import com.berlin.aflami.component.ThemeAndLocalePreviews
 import com.berlin.aflami.navigation.LoginDestination
 import com.berlin.aflami.navigation.MyRatingDestination
@@ -49,10 +51,15 @@ fun ProfileScreen(
 ) {
     val profileScreenState by viewModel.state.collectAsStateWithLifecycle()
     val navController = Theme.navController
-    if (profileScreenState.isLoggedIn) {
-        ProfileContent(profileScreenState, viewModel)
-    } else {
-        RequiredLoggedInPlaceholder() {
+    when (profileScreenState.isLoggedIn) {
+        null -> {
+            CircularProgressIndicator(
+                modifier = Modifier.fillMaxSize(),
+                text = stringResource(R.string.loading)
+            )
+        }
+        true -> ProfileContent(profileScreenState, viewModel)
+        false -> RequiredLoggedInPlaceholder {
             navController.navigate(LoginDestination)
         }
     }

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/main/MainActivityViewModel.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/main/MainActivityViewModel.kt
@@ -4,10 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import usecase.auth.GetLoginUseCase
@@ -21,17 +18,15 @@ class MainActivityViewModel @Inject constructor(
 
     ) : ViewModel() {
 
-    private val _state = MutableStateFlow(MainUiState())
+    private val _state = MutableStateFlow(MainUiState(isLoading = true))
     val state = _state.asStateFlow()
-    val isLoggedInState: StateFlow<Boolean> = isLoggedInUseCase()
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), false)
 
 
     init {
         viewModelScope.launch {
             val isFirstEntry = getFirstEntryUseCase()
-//            val isLoggedIn: Flow<Boolean> = isLoggedInUseCase()
-            isLoggedInState.collect { loggedIn ->
+
+            isLoggedInUseCase().collect { loggedIn ->
                 _state.update {
                     it.copy(
                         isLoading = false,
@@ -40,11 +35,6 @@ class MainActivityViewModel @Inject constructor(
                     )
                 }
             }
-            _state.value = MainUiState(
-                isLoading = false,
-                isFirstEntry = isFirstEntry,
-                isLoggedIn = isLoggedInState.value
-            )
         }
     }
 }

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/profile/ProfileUiState.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/profile/ProfileUiState.kt
@@ -22,7 +22,7 @@ data class ProfileUiState(
     val isEnglishSelected: Boolean = selectedLanguage == AppLanguage.EN.name,
     val isArabicSelected: Boolean = selectedLanguage == AppLanguage.AR.name,
     val activeDialog: ProfileDialogType = ProfileDialogType.NONE,
-    val isLoggedIn: Boolean = false,
+    val isLoggedIn: Boolean? = null,
     val isStrictSelected: Boolean = true,
     val isModeratedSelected: Boolean = false,
     val isOffSelected: Boolean = false,

--- a/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/profile/ProfileViewModel.kt
+++ b/presentation/viewModel/src/main/kotlin/com/berlin/aflami/viewmodel/profile/ProfileViewModel.kt
@@ -64,7 +64,6 @@ class ProfileViewModel @Inject constructor(
     private fun checkLoginStatus() {
         viewModelScope.launch {
             getLoginStatus().collect { loggedIn ->
-
                 updateState { it.copy(isLoggedIn = loggedIn) }
             }
         }


### PR DESCRIPTION
# Fix Flicker on Profile Screen During User Login Check

## Description
This PR addresses a flickering issue on the Profile screen when opening the app. Initially, the placeholder for login appeared for a brief moment, even when the user was already logged in. The issue was caused by the isLoggedIn value being initialized as null in the ProfileUiState, which led to the placeholder being shown before the real state was fetched.

---

## Changes Made
List the changes introduced in this pull request:
Updated the ProfileUiState to initialize isLoggedIn as null instead of false.

In ProfileScreen, a loading state (when isLoggedIn is null) is now shown, preventing the flicker from occurring.

Refined the UI logic to handle the loading state properly, ensuring a seamless transition from loading to the actual user data.

Update the mainActivityViewModel to initiate the login state in a better way and initiate its loading state to start with isLoading=true to support the splash screen in the mainActivity

Changed the keyboard type in the password text field in the login screen to be of type Password, to prevent autocomplete and suggestion in devices keyboard

---

## Checklist
- [x] Changes have been tested manually and verified.
- [x] PR includes at most one single feature.
- [x] Commit messages should follow the atomic commits convention.

---
